### PR TITLE
Add checking of self- and local html anchors

### DIFF
--- a/examples/anchors_other.html
+++ b/examples/anchors_other.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <a href="./anchors_self.html#foo">foo is good</a>
+    <a href="./anchors_self.html#bar">bar is ambiguous</a>
+    <a href="./anchors_self.html#baz">baz is missing</a>
+  </body>
+</html>

--- a/examples/anchors_self.html
+++ b/examples/anchors_self.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <a name="foo"></a><h1>FOO</h1>
+    <a name="bar"></a><h2>BAR</h2>
+    <a name="bar"></a><h3>ANOTHER BAR</h3>
+
+    <a href="#foo">foo is good</a>
+    <a href="#bar">bar is ambiguous</a>
+    <a href="#baz">baz is missing</a>
+  </body>
+</html>

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -25,3 +25,14 @@ def test_link_ext(testdir):
     testdir.copy_example('markdown.md')
     result = testdir.runpytest("-v", "--check-links", "--links-ext=.md,rst")
     result.assert_outcomes(passed=15, failed=6)
+
+def test_anchors_self(testdir):
+    testdir.copy_example('anchors_self.html')
+    result = testdir.runpytest("-v", "--check-links", "--check-anchors")
+    result.assert_outcomes(passed=1, failed=2)
+
+def test_anchors_other(testdir):
+    testdir.copy_example('anchors_self.html')
+    testdir.copy_example('anchors_other.html')
+    result = testdir.runpytest("-v", "--check-links", "--check-anchors", "anchors_other.html")
+    result.assert_outcomes(passed=1, failed=2)


### PR DESCRIPTION
Thanks for warming this back up!

I'd like to be able to be sure anchors are all on the up-and-up, especially when dealing with generated content.

This proposes the minimal changes for my purposes, but tries to tread lightly: to avoid breaking existing runs that might have broken anchors, it adds a new CLI switch, `--check-anchors` which, when given, will check `#` urls in all local source files that target local HTML files.

To avoid introducing new complexity, it doesn't:
- re-render other targets (only looks in `.html`)
  - perhaps we need a store of all the parsed documents?
- download remote content and parse it
  - it's already DDoStastic enough as it is

There's probably some follow-on, but this would already help me a lot!