### PR TITLE
Use requests(-cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+envs/
 
 # Spyder project settings
 .spyderproject
@@ -92,3 +93,6 @@ ENV/
 # pbr-generated files
 AUTHORS
 ChangeLog
+
+# caches
+*.sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_install:
 install:
   - pip install --upgrade .[cache] pytest-cov
 script:
-  - pytest --cov pytest_check_links
+  # disable automatic inclusion for coverage
+  - pytest -p no:check-links --cov pytest_check_links --cov-report term-missing
 after_success:
   - pip install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
 dist: xenial
 python:
+  - 3.8
   - 3.7
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
 before_install:
   - pip install --upgrade setuptools pip
 install:
-  - pip install --upgrade . pytest-cov
+  - pip install --upgrade .[cache] pytest-cov
 script:
   - pytest --cov pytest_check_links
 after_success:

--- a/README.md
+++ b/README.md
@@ -69,17 +69,18 @@ for more information.
 
 Time to cache link responses (seconds).
 
-#### --check-links-cache-allowable-codes
-
-HTTP responses to cache. As opposed to the default `requests-cache` behavior
-of caching only `200` responses, _all_ responses will be cached, to avoid repeatedly
-requesting broken links.
-
 #### --check-links-cache-backend-opt
 
 Backend-specific options for link cache, provided as `key:value`. These are passed
 directly to the `requests_cache.CachedSession` constructor, as they vary depending
 on the backend.
+
+Values will be parsed as JSON first, so to overload the default of caching all
+HTTP response codes (which requires a list of `int`s):
+
+```bash
+--check-links-backend-opt allowable_codes:[200]
+```
 
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -2,26 +2,88 @@
 
 pytest plugin that checks URLs for HTML-containing files.
 
-Supported files:
+## Supported files
 
-- .html
-- .rst
-- .md (TODO: select renderer)
-- .ipynb (requires nbconvert)
+- `.html`
+- `.rst`
+- `.md` (TODO: select renderer)
+- `.ipynb` (requires `nbconvert`)
 
-Install:
+## Install
 
     pip install pytest-check-links
 
-Use:
+## Use
 
     pytest --check-links mynotebook.ipynb
 
+## Configure
 
-TODO:
+#### --links-ext
+
+> default: `md,rst,html,ipynb`
+
+A comma-separated list of extensions to check
+
+#### --check-anchors
+
+Also check whether links with `#fragments` to local HTML files actually exist,
+and point to exactly one named anchor.
+
+### Cache
+
+Caching requires the installation of `requests-cache`.
+
+    pip install requests-cache
+
+If enabled, each occurance of a link will be checked, no matter how many times
+it appears in a collection of files to check.
+
+#### --check-links-cache
+
+Cache requests when checking links. Caching is disabled by default, and this option
+must be provided, even if other cache configuration options are provided.
+
+#### --check-links-cache-name
+
+> default: `.pytest-check-links-cache`
+
+Name of link cache, either the base name of a file or similar, depending on backend.
+
+#### --check-links-cache-backend
+
+> default: `sqlite3`
+
+Cache persistence backend. The other known backends are:
+- `memory`
+- `redis`
+- `mongodb`
+
+See the [requests-cache documentation](https://requests-cache.readthedocs.io)
+for more information.
+
+#### --check-links-cache-expire-after
+
+> default: `None` (unlimited)
+
+Time to cache link responses (seconds).
+
+#### --check-links-cache-allowable-codes
+
+HTTP responses to cache. As opposed to the default `requests-cache` behavior
+of caching only `200` responses, _all_ responses will be cached, to avoid repeatedly
+requesting broken links.
+
+#### --check-links-cache-backend-opt
+
+Backend-specific options for link cache, provided as `key:value`. These are passed
+directly to the `requests_cache.CachedSession` constructor, as they vary depending
+on the backend.
+
+
+## TODO
 
 - pick a markdown renderer (probably commonmark) or make the markdown renderer pluggable
 - options for validating links (allow absolute links, only remote or local, etc.)
 - check internal links (`#anchors`)
 - find URLs in Python docstrings
-- test myself, obvs!

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ A comma-separated list of extensions to check
 
 #### --check-anchors
 
-Also check whether links with `#fragments` to local HTML files actually exist,
-and point to exactly one named anchor.
+Also check whether links with `#anchors` HTML files (either local, or with
+served with `html` in the `Content-Type`) actually exist, and point to _exactly one_
+named anchor.
 
 ### Cache
 

--- a/examples/anchors_remote.html
+++ b/examples/anchors_remote.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <a href="https://www.w3.org/TR/REC-html40/struct/links.html#anchors">anchors exists</a>
+    <a href="https://www.w3.org/TR/REC-html40/struct/links.html#no-such-anchor">doesn't exist</a>
+  </body>
+</html>

--- a/examples/httpbin.md
+++ b/examples/httpbin.md
@@ -1,0 +1,6 @@
+- [one](https://httpbin.org/delay/0.25#1)
+- [two](https://httpbin.org/delay/0.25#2)
+- [three](https://httpbin.org/delay/0.25#3)
+- [four](https://httpbin.org/delay/0.25#4)
+- [five](https://httpbin.org/delay/0.25#5)
+- [six](https://httpbin.org/delay/0.25#6)

--- a/pytest_check_links/args.py
+++ b/pytest_check_links/args.py
@@ -32,5 +32,7 @@ class StoreCacheAction(argparse.Action):
         elif dest == "backend_opt":
             key, value = values.split(":", 1)
             kwargs[key] = value
+        elif dest == "allowable_codes":
+            kwargs[key] = list(map(int, value.split(",")))
         else:
             kwargs[dest] = values

--- a/pytest_check_links/args.py
+++ b/pytest_check_links/args.py
@@ -1,5 +1,5 @@
 import argparse
-
+import json
 
 class StoreExtensionsAction(argparse.Action):
 
@@ -30,9 +30,10 @@ class StoreCacheAction(argparse.Action):
         elif dest == "expire_after":
             kwargs["expire_after"] = float(values)
         elif dest == "backend_opt":
-            key, value = values.split(":", 1)
-            kwargs[key] = value
-        elif dest == "allowable_codes":
-            kwargs[key] = list(map(int, value.split(",")))
+            key, value = str(values).split(":", 1)
+            try:
+                kwargs[key] = json.loads(value)
+            except:
+                kwargs[key] = value
         else:
             kwargs[dest] = values

--- a/pytest_check_links/args.py
+++ b/pytest_check_links/args.py
@@ -14,3 +14,23 @@ class StoreExtensionsAction(argparse.Action):
 
     def parse_extensions(self, csv):
         return {'.%s' % ext.lstrip('.') for ext in csv.split(',')}
+
+
+class StoreCacheAction(argparse.Action):
+    """Build the cache session kwargs
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        ns_name = "check_links_cache_kwargs"
+        if not hasattr(namespace, ns_name):
+            setattr(namespace, ns_name, {})
+        dest = self.dest.replace("check_links_cache_", "")
+        kwargs = namespace.check_links_cache_kwargs
+        if dest == "name":
+            kwargs["cache_name"] = values
+        elif dest == "expire_after":
+            kwargs["expire_after"] = float(values)
+        elif dest == "backend_opt":
+            key, value = values.split(":", 1)
+            kwargs[key] = value
+        else:
+            kwargs[dest] = values

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -246,7 +246,11 @@ class LinkItem(pytest.Item):
     def fetch_with_retries(self, url, retries=3):
         """Fetch a URL, optionally retrying after a delay (by header)
         """
-        response = self.parent.requests_session.get(url)
+
+        try:
+            response = self.parent.requests_session.get(url)
+        except Exception as err:
+            raise BrokenLinkError(url, "%s" % err)
 
         if response.status_code >= 400:
             if retries and self.sleep(response):

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -39,15 +39,15 @@ def pytest_addoption(parser):
     group.addoption('--check-links-cache', action='store_true',
         help="Cache requests when checking links")
     group.addoption('--check-links-cache-name', action=StoreCacheAction,
-        default="pytest-check-links", help="Name of link cache")
+        help="Name of link cache")
     group.addoption('--check-links-cache-backend', action=StoreCacheAction,
-        default=None, help="Cache persistence backend")
+        help="Cache persistence backend")
     group.addoption('--check-links-cache-expire-after', action=StoreCacheAction,
-        default=300, help="Time to cache link responses (seconds)")
+        help="Time to cache link responses (seconds)")
     group.addoption('--check-links-cache-allowable-codes', action=StoreCacheAction,
-        default=[200, 404], help="HTTP response codes to cache")
+        help="HTTP response codes to cache")
     group.addoption('--check-links-cache-backend-opt', action=StoreCacheAction,
-        default=[200, 404], help="Backend-specific options for link cache")
+        help="Backend-specific options for link cache, specfied as `opt:value`")
 
 
 def pytest_configure(config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pytest >= 2.8
-html5lib
-six
-nbformat
-nbconvert
 docutils
+html5lib
+nbconvert
+nbformat
+pytest >= 2.8
+requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,10 @@ pytest11 =
 console_scripts =
     pytest-check-links = pytest_check_links.__main__:main
 
+[options.extras_require]
+cache =
+    requests-cache
+
 [pep8]
 ignore=E128
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+here = os.path.dirname(os.path.abspath(__file__))
+examples = os.path.join(os.path.dirname(here), 'examples')

--- a/test/test_anchors.py
+++ b/test/test_anchors.py
@@ -1,0 +1,27 @@
+from . import examples
+
+import pytest
+
+
+@pytest.fixture
+def anchor_args():
+    return ["-v", "--check-links", "--check-anchors"]
+
+
+def test_anchors_local_self(testdir, anchor_args):
+    testdir.copy_example('anchors_self.html')
+    result = testdir.runpytest(*anchor_args)
+    result.assert_outcomes(passed=1, failed=2)
+
+
+def test_anchors_local_other(testdir, anchor_args):
+    testdir.copy_example('anchors_self.html')
+    testdir.copy_example('anchors_other.html')
+    result = testdir.runpytest(*anchor_args, "anchors_other.html")
+    result.assert_outcomes(passed=1, failed=2)
+
+
+def test_anchors_external(testdir, anchor_args):
+    testdir.copy_example('anchors_remote.html')
+    result = testdir.runpytest(*anchor_args)
+    result.assert_outcomes(passed=1, failed=1)

--- a/test/test_anchors.py
+++ b/test/test_anchors.py
@@ -17,7 +17,8 @@ def test_anchors_local_self(testdir, anchor_args):
 def test_anchors_local_other(testdir, anchor_args):
     testdir.copy_example('anchors_self.html')
     testdir.copy_example('anchors_other.html')
-    result = testdir.runpytest(*anchor_args, "anchors_other.html")
+    args = anchor_args + ["anchors_other.html"]
+    result = testdir.runpytest(*args)
     result.assert_outcomes(passed=1, failed=2)
 
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -23,6 +23,7 @@ def assert_sqlite(testdir, name=None, tmpdir=None, exists=True):
     else:
         assert not caches
 
+
 @pytest.mark.parametrize("cache_name", [
     None,
     "custom-cache"
@@ -61,7 +62,6 @@ def test_cache_expiry(testdir, base_args, cache_name, tmpdir):
     result.assert_outcomes(**expected)
 
     assert t5 - t4 > t3 - t2, "cache did not expire"
-
 
 
 def test_cache_memory(testdir, base_args):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -33,7 +33,7 @@ def test_cache_expiry(testdir, base_args, cache_name, tmpdir):
     """
     testdir.copy_example('linkcheck.ipynb')
 
-    args = [*base_args, "--check-links-cache-expire-after", "2"]
+    args = base_args + ["--check-links-cache-expire-after", "2"]
     if cache_name:
         args += ["--check-links-cache-name", os.path.join(str(tmpdir), cache_name)]
     expected = dict(passed=3, failed=3)
@@ -67,7 +67,7 @@ def test_cache_expiry(testdir, base_args, cache_name, tmpdir):
 def test_cache_memory(testdir, base_args):
     """will the memory backend cache links inside a run?
     """
-    args = [*base_args, "--check-links-cache-backend", "memory"]
+    args = base_args + ["--check-links-cache-backend", "memory"]
     expected = dict(passed=3, failed=0)
 
     testdir.copy_example('httpbin.md')

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -126,3 +126,16 @@ def test_cache_retry(testdir, memory_args):
         assert len(attempts) == 10
     finally:
         requests_cache.CachedSession.get = _get
+
+
+def test_cache_backend_opts(testdir, base_args):
+    testdir.copy_example('httpbin.md')
+    args = base_args + [
+        "--check-links-cache-backend-opt", "fast_save:true",
+        "--check-links-cache-name", "foo",
+        "--check-links-cache-backend-opt", "extension:.db",
+        "--check-links-cache-backend-opt", "allowable_codes:[200]"
+    ]
+    result = testdir.runpytest(*args)
+    result.assert_outcomes(passed=6, failed=0)
+    assert_sqlite(testdir, name="foo.db")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -6,12 +6,19 @@ from glob import glob
 
 import pytest
 
+import requests_cache
+
 from . import examples
 
 
 @pytest.fixture
 def base_args():
     return ["-v", "--check-links", "--check-links-cache"]
+
+
+@pytest.fixture
+def memory_args(base_args):
+    return base_args + ["--check-links-cache-backend", "memory"]
 
 
 def assert_sqlite(testdir, name=None, tmpdir=None, exists=True):
@@ -64,17 +71,16 @@ def test_cache_expiry(testdir, base_args, cache_name, tmpdir):
     assert t5 - t4 > t3 - t2, "cache did not expire"
 
 
-def test_cache_memory(testdir, base_args):
+def test_cache_memory(testdir, memory_args):
     """will the memory backend cache links inside a run?
     """
-    args = base_args + ["--check-links-cache-backend", "memory"]
     expected = dict(passed=3, failed=0)
 
     testdir.copy_example('httpbin.md')
 
     def run(passed):
         t0 = time.time()
-        result = testdir.runpytest(*args)
+        result = testdir.runpytest(*memory_args)
         t1 = time.time()
         result.assert_outcomes(passed=passed, failed=0)
         assert_sqlite(testdir, exists=False)
@@ -91,3 +97,32 @@ def test_cache_memory(testdir, base_args):
     d1 = run(36)
     # allow a healthy savings margin for network flake
     assert d1 < d0 * 4
+
+
+def test_cache_retry(testdir, memory_args):
+    """will a Retry-After header work with cache?
+    """
+
+    testdir.copy_example('httpbin.md')
+
+    attempts = []
+
+    _get = requests_cache.CachedSession.get
+
+    def mock_get(*args, **kwargs):
+        response = _get(*args, **kwargs)
+        if len(attempts) < 5:
+            response.status_code = 502
+            response.headers['Retry-After'] = '0'
+        attempts.append([args, kwargs])
+        return response
+
+    requests_cache.CachedSession.get = mock_get
+
+    result = testdir.runpytest(*memory_args)
+
+    try:
+        result.assert_outcomes(passed=5, failed=1)
+        assert len(attempts) == 10
+    finally:
+        requests_cache.CachedSession.get = _get

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -84,8 +84,8 @@ def test_cache_memory(testdir, base_args):
 
     for i in range(5):
         shutil.copy(
-            os.path.join(testdir.tmpdir, "httpbin.md"),
-            os.path.join(testdir.tmpdir, "httpbin{}.md".format(i))
+            os.path.join(str(testdir.tmpdir), "httpbin.md"),
+            os.path.join(str(testdir.tmpdir), "httpbin{}.md".format(i))
         )
 
     d1 = run(36)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,0 +1,83 @@
+import os
+import time
+import shutil
+
+from glob import glob
+
+import pytest
+
+from . import examples
+
+
+@pytest.fixture
+def base_args():
+    return ["-v", "--check-links", "--check-links-cache"]
+
+
+def assert_sqlite(testdir, name=".pytest-check-links-cache.sqlite", exists=True):
+    caches = list(glob(os.path.join(testdir.tmpdir, name)))
+    if exists:
+        assert caches
+    else:
+        assert not caches
+
+
+def test_cache_expiry(testdir, base_args):
+    """will the default sqlite3 backend persist and then expire?
+    """
+    testdir.copy_example('linkcheck.ipynb')
+
+    args = [*base_args, "--check-links-cache-expire-after", "2"]
+    expected = dict(passed=3, failed=3)
+    t0 = time.time()
+    result = testdir.runpytest(*args)
+    t1 = time.time()
+    result.assert_outcomes(**expected)
+
+    assert_sqlite(testdir)
+
+    t2 = time.time()
+    result = testdir.runpytest(*args)
+    t3 = time.time()
+    result.assert_outcomes(**expected)
+
+    assert t1 - t0 > t3 - t2, "cache did not make second run faster"
+
+    time.sleep(2)
+
+    t4 = time.time()
+    result = testdir.runpytest(*args)
+    t5 = time.time()
+    result.assert_outcomes(**expected)
+
+    assert t5 - t4 > t3 - t2, "cache did not expire"
+
+
+
+def test_cache_memory(testdir, base_args):
+    """will the memory backend cache links inside a run?
+    """
+    args = [*base_args, "--check-links-cache-backend", "memory"]
+    expected = dict(passed=3, failed=0)
+
+    testdir.copy_example('httpbin.md')
+
+    def run(passed):
+        t0 = time.time()
+        result = testdir.runpytest(*args)
+        t1 = time.time()
+        result.assert_outcomes(passed=passed, failed=0)
+        assert_sqlite(testdir, exists=False)
+        return t1 - t0
+
+    d0 = run(6)
+
+    for i in range(5):
+        shutil.copy(
+            os.path.join(testdir.tmpdir, "httpbin.md"),
+            os.path.join(testdir.tmpdir, "httpbin{}.md".format(i))
+        )
+
+    d1 = run(36)
+    # allow a healthy savings margin for network flake
+    assert d1 < d0 * 4

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -22,14 +22,3 @@ def test_link_ext(testdir):
     testdir.copy_example('markdown.md')
     result = testdir.runpytest("-v", "--check-links", "--links-ext=.md,rst")
     result.assert_outcomes(passed=15, failed=6)
-
-def test_anchors_self(testdir):
-    testdir.copy_example('anchors_self.html')
-    result = testdir.runpytest("-v", "--check-links", "--check-anchors")
-    result.assert_outcomes(passed=1, failed=2)
-
-def test_anchors_other(testdir):
-    testdir.copy_example('anchors_self.html')
-    testdir.copy_example('anchors_other.html')
-    result = testdir.runpytest("-v", "--check-links", "--check-anchors", "anchors_other.html")
-    result.assert_outcomes(passed=1, failed=2)

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -1,8 +1,4 @@
-import os
-import time
-
-here = os.path.dirname(os.path.abspath(__file__))
-examples = os.path.join(os.path.dirname(here), 'examples')
+from . import examples
 
 
 def test_ipynb(testdir):
@@ -37,30 +33,3 @@ def test_anchors_other(testdir):
     testdir.copy_example('anchors_other.html')
     result = testdir.runpytest("-v", "--check-links", "--check-anchors", "anchors_other.html")
     result.assert_outcomes(passed=1, failed=2)
-
-def test_cache_expiry(testdir):
-    testdir.copy_example('linkcheck.ipynb')
-
-    args = ["-v", "--check-links", "--check-links-cache",
-            "--check-links-cache-expire-after", "2"]
-    expected = dict(passed=3, failed=3)
-    t0 = time.time()
-    result = testdir.runpytest(*args)
-    t1 = time.time()
-    result.assert_outcomes(**expected)
-
-    t2 = time.time()
-    result = testdir.runpytest(*args)
-    t3 = time.time()
-    result.assert_outcomes(**expected)
-
-    assert t1 - t0 > t3 - t2, "cache did not make second run faster"
-
-    time.sleep(2)
-
-    t4 = time.time()
-    result = testdir.runpytest(*args)
-    t5 = time.time()
-    result.assert_outcomes(**expected)
-
-    assert t5 - t4 > t3 - t2, "cache did not expire"


### PR DESCRIPTION
fixes #11

Part 1:
This adopts `requests` instead of relying on stdlib and six (though requests _also_ uses `six`, but no longer importing it). This isn't free, by any stretch, as it does bring along a number of transient deps, but Part 2 will be a lot less predictable without:

<details>
<pre>
# sorry for the conda noise... pip still doesn't have dry-run in 2020?
--- deps.old	2020-04-22 20:54:52.258914604 -0400
+++ deps.new	2020-04-22 20:54:40.494814215 -0400
@@ -11,7 +11,7 @@
     - nbconvert
     - nbformat
     - pytest
-    - six
+    - requests
 
 
 The following NEW packages will be INSTALLED:
@@ -20,13 +20,18 @@
   _openmp_mutex      conda-forge/linux-64::_openmp_mutex-4.5-0_gnu
   attrs              conda-forge/noarch::attrs-19.3.0-py_0
   bleach             conda-forge/noarch::bleach-3.1.4-pyh9f0ad1d_0
+  brotlipy           conda-forge/linux-64::brotlipy-0.7.0-py38h1e0a361_1000
   ca-certificates    conda-forge/linux-64::ca-certificates-2020.4.5.1-hecc5488_0
   certifi            conda-forge/linux-64::certifi-2020.4.5.1-py38h32f6830_0
+  cffi               conda-forge/linux-64::cffi-1.14.0-py38hd463f26_0
+  chardet            conda-forge/linux-64::chardet-3.0.4-py38h32f6830_1006
+  cryptography       conda-forge/linux-64::cryptography-2.8-py38h766eaa4_2
   decorator          conda-forge/noarch::decorator-4.4.2-py_0
   defusedxml         conda-forge/noarch::defusedxml-0.6.0-py_0
   docutils           conda-forge/linux-64::docutils-0.16-py38h32f6830_1
   entrypoints        conda-forge/linux-64::entrypoints-0.3-py38h32f6830_1001
   html5lib           conda-forge/noarch::html5lib-1.0.1-py_0
+  idna               conda-forge/noarch::idna-2.9-py_1
   importlib-metadata conda-forge/linux-64::importlib-metadata-1.6.0-py38h32f6830_0
   importlib_metadata conda-forge/noarch::importlib_metadata-1.6.0-0
   ipython_genutils   conda-forge/noarch::ipython_genutils-0.2.0-py_1
@@ -51,19 +56,24 @@
   pip                conda-forge/noarch::pip-20.0.2-py_2
   pluggy             conda-forge/linux-64::pluggy-0.13.1-py38_0
   py                 conda-forge/noarch::py-1.8.1-py_0
+  pycparser          conda-forge/noarch::pycparser-2.20-py_0
   pygments           conda-forge/noarch::pygments-2.6.1-py_0
+  pyopenssl          conda-forge/noarch::pyopenssl-19.1.0-py_1
   pyparsing          conda-forge/noarch::pyparsing-2.4.7-pyh9f0ad1d_0
   pyrsistent         conda-forge/linux-64::pyrsistent-0.16.0-py38h1e0a361_0
+  pysocks            conda-forge/linux-64::pysocks-1.7.1-py38h32f6830_1
   pytest             conda-forge/linux-64::pytest-5.4.1-py38h32f6830_0
   python             conda-forge/linux-64::python-3.8.2-he5300dc_6_cpython
   python_abi         conda-forge/linux-64::python_abi-3.8-1_cp38
   readline           conda-forge/linux-64::readline-8.0-hf8c457e_0
+  requests           conda-forge/noarch::requests-2.23.0-pyh8c360ce_2
   setuptools         conda-forge/linux-64::setuptools-46.1.3-py38h32f6830_0
   six                conda-forge/noarch::six-1.14.0-py_1
   sqlite             conda-forge/linux-64::sqlite-3.30.1-hcee41ef_0
   testpath           conda-forge/noarch::testpath-0.4.4-py_0
   tk                 conda-forge/linux-64::tk-8.6.10-hed695b0_0
   traitlets          conda-forge/linux-64::traitlets-4.3.3-py38h32f6830_1
+  urllib3            conda-forge/noarch::urllib3-1.25.9-py_0
   wcwidth            conda-forge/noarch::wcwidth-0.1.9-pyh9f0ad1d_0
   webencodings       conda-forge/noarch::webencodings-0.5.1-py_1
   wheel              conda-forge/noarch::wheel-0.34.2-py_1

</pre>
</details>

Part 2:

> WIP

As discussed over on #11, the idea is to use the excellent [requests-cache](https://github.com/reclosedev/requests-cache) to implement robust caching, with the sketch of configurables presented there.