### PR TITLE
Clean up metadata for dist generation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [metadata]
 name = pytest_check_links
 author = Jupyter Development Team
@@ -10,6 +7,7 @@ description-file = README.md
 long-description-content-type = text/markdown
 home-page = https://github.com/jupyterlab/pytest-check-links
 license = BSD-3-Clause
+python-requires = >=3.5
 classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
Prevents creating universal wheels, and make a sane python-requires.