### PR TITLE
Expand matched anchor targets to include any element with an id

### DIFF
--- a/examples/anchors_self.html
+++ b/examples/anchors_self.html
@@ -3,10 +3,12 @@
   <head></head>
   <body>
     <a name="foo"></a><h1>FOO</h1>
+    <a id="boo"></a><h1>BOO</h1>
     <a name="bar"></a><h2>BAR</h2>
     <a name="bar"></a><h3>ANOTHER BAR</h3>
 
-    <a href="#foo">foo is good</a>
+    <a href="#foo">foo is good (uses name)</a>
+    <a href="#boo">boo is good (uses id)</a>
     <a href="#bar">bar is ambiguous</a>
     <a href="#baz">baz is missing</a>
   </body>

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -246,7 +246,7 @@ class LinkItem(pytest.Item):
     def handle_anchor(self, parsed, anchor):
         """Verify an anchor exists in the parsed HTML
         """
-        anchors = parsed.findall('*//a[@name="{}"]'.format(anchor))
+        anchors = parsed.findall('*//*[@name="{0}" or @id="{0}"]'.format(anchor))
 
         if not anchors:
             raise BrokenLinkError(self.target, "Missing anchor: %s" % anchor)

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -246,7 +246,8 @@ class LinkItem(pytest.Item):
     def handle_anchor(self, parsed, anchor):
         """Verify an anchor exists in the parsed HTML
         """
-        anchors = parsed.findall('*//*[@name="{0}" or @id="{0}"]'.format(anchor))
+        anchors = set(parsed.findall('*//a[@name="{}"]'.format(anchor)))
+        anchors |= set(parsed.findall('*//*[@id="{}"]'.format(anchor)))
 
         if not anchors:
             raise BrokenLinkError(self.target, "Missing anchor: %s" % anchor)

--- a/test/test_anchors.py
+++ b/test/test_anchors.py
@@ -11,7 +11,7 @@ def anchor_args():
 def test_anchors_local_self(testdir, anchor_args):
     testdir.copy_example('anchors_self.html')
     result = testdir.runpytest(*anchor_args)
-    result.assert_outcomes(passed=1, failed=2)
+    result.assert_outcomes(passed=2, failed=2)
 
 
 def test_anchors_local_other(testdir, anchor_args):


### PR DESCRIPTION
Had a chance to test out the plugin on a non-trivial sphinx-generated site, and found that `name` is actually [obsolete](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Obsolete_attributes), with `id` being the preferred attribute. Given I've seen `name` in the wild, i've just updated the xpath to check for `a` names as well as anything with an `id`.