### PR TITLE
Update for recommended usage of CheckLinks

### DIFF
--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -61,8 +61,9 @@ def pytest_collect_file(path, parent):
     if config.option.check_links:
         requests_session = ensure_requests_session(config)
         if path.ext.lower() in config.option.links_ext:
-            return CheckLinks.from_parent(path, parent, requests_session, config.option.check_anchors)
-
+            if hasattr(CheckLinks, "from_parent"):
+                return CheckLinks.from_parent(path, parent, requests_session, config.option.check_anchors)
+            return CheckLinks(path, parent, requests_session, config.option.check_anchors)
 
 def ensure_requests_session(config):
     """Build the singleton requests.Session (or subclass)

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -61,9 +61,10 @@ def pytest_collect_file(path, parent):
     if config.option.check_links:
         requests_session = ensure_requests_session(config)
         if path.ext.lower() in config.option.links_ext:
+            check_anchors = config.option.check_anchors
             if hasattr(CheckLinks, "from_parent"):
-                return CheckLinks.from_parent(path, parent, requests_session, config.option.check_anchors)
-            return CheckLinks(path, parent, requests_session, config.option.check_anchors)
+                return CheckLinks.from_parent(parent, path=path, requests_session=requests_session, check_anchors=check_anchors)
+            return CheckLinks(path=path, parent=parent, requests_session=requests_session, check_anchors=check_anchors)
 
 def ensure_requests_session(config):
     """Build the singleton requests.Session (or subclass)
@@ -91,8 +92,8 @@ def ensure_requests_session(config):
 
 class CheckLinks(pytest.File):
     """Check the links in a file"""
-    def __init__(self, path, parent, requests_session, check_anchors=False):
-        super(CheckLinks, self).__init__(path, parent)
+    def __init__(self, parent=None, path=None, requests_session=None, check_anchors=False):
+        super(CheckLinks, self).__init__(parent=parent, path=path)
         self.check_anchors = check_anchors
         self.requests_session = requests_session
 

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -61,7 +61,7 @@ def pytest_collect_file(path, parent):
     if config.option.check_links:
         requests_session = ensure_requests_session(config)
         if path.ext.lower() in config.option.links_ext:
-            return CheckLinks(path, parent, requests_session, config.option.check_anchors)
+            return CheckLinks.from_parent(path, parent, requests_session, config.option.check_anchors)
 
 
 def ensure_requests_session(config):

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -192,8 +192,8 @@ def links_in_html(base_name, parent, html):
                     # ignore non-http links (mailto:, data:, etc.)
                     continue
             if hasattr(LinkItem, "from_parent"):
-                yield LinkItem.from_parent(parent, name=name, url=url, parsed=parsed)
-            yield LinkItem(name=name, parent=parent, url=url, parsed=parsed)
+                yield LinkItem.from_parent(parent, name=name, target=url, parsed=parsed)
+            yield LinkItem(name=name, parent=parent, target=url, parsed=parsed)
 
 
 class LinkItem(pytest.Item):

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -191,7 +191,9 @@ def links_in_html(base_name, parent, html):
                 if proto.lower() not in {'http', 'https'}:
                     # ignore non-http links (mailto:, data:, etc.)
                     continue
-            yield LinkItem(name, parent, url, parsed)
+            if hasattr(LinkItem, "from_parent"):
+                yield LinkItem.from_parent(parent, name=name, url=url, parsed=parsed)
+            yield LinkItem(name=name, parent=parent, url=url, parsed=parsed)
 
 
 class LinkItem(pytest.Item):
@@ -204,7 +206,7 @@ class LinkItem(pytest.Item):
         parsed (xml.etree.ElementTree.Element): The parsed HTML
         description (str, optional): The description to be used in the report header
     """
-    def __init__(self, name, parent, target, parsed, description=''):
+    def __init__(self, name=None, parent=None, target=None, parsed=None, description=''):
         super(LinkItem, self).__init__(name, parent)
         self.target = target
         self.parsed = parsed

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -56,7 +56,7 @@ def pytest_configure(config):
         validate_extensions(config.option.links_ext)
 
 
-def pytest_collect_file(fspath, parent):
+def pytest_collect_file(path, parent):
     config = parent.config
     if config.option.check_links:
         requests_session = ensure_requests_session(config)

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -93,7 +93,10 @@ def ensure_requests_session(config):
 class CheckLinks(pytest.File):
     """Check the links in a file"""
     def __init__(self, parent=None, path=None, requests_session=None, check_anchors=False):
-        super(CheckLinks, self).__init__(parent=parent, path=path)
+        if hasattr(pytest.File, "from_parent"):
+            super(CheckLinks, self).__init__(parent, path=path)
+        else:
+            super(CheckLinks, self).__init__(path, parent)
         self.check_anchors = check_anchors
         self.requests_session = requests_session
 

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -193,7 +193,8 @@ def links_in_html(base_name, parent, html):
                     continue
             if hasattr(LinkItem, "from_parent"):
                 yield LinkItem.from_parent(parent, name=name, target=url, parsed=parsed)
-            yield LinkItem(name=name, parent=parent, target=url, parsed=parsed)
+            else:
+                yield LinkItem(name=name, parent=parent, target=url, parsed=parsed)
 
 
 class LinkItem(pytest.Item):

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -63,8 +63,8 @@ def pytest_collect_file(path, parent):
         if path.ext.lower() in config.option.links_ext:
             check_anchors = config.option.check_anchors
             if hasattr(CheckLinks, "from_parent"):
-                return CheckLinks.from_parent(parent, fspath=fspath, requests_session=requests_session, check_anchors=check_anchors)
-            return CheckLinks(fspath=fspath, parent=parent, requests_session=requests_session, check_anchors=check_anchors)
+                return CheckLinks.from_parent(parent, fspath=path, requests_session=requests_session, check_anchors=check_anchors)
+            return CheckLinks(fspath=path, parent=parent, requests_session=requests_session, check_anchors=check_anchors)
 
 def ensure_requests_session(config):
     """Build the singleton requests.Session (or subclass)

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -93,10 +93,7 @@ def ensure_requests_session(config):
 class CheckLinks(pytest.File):
     """Check the links in a file"""
     def __init__(self, parent=None, fspath=None, requests_session=None, check_anchors=False):
-        if hasattr(pytest.File, "from_parent"):
-            super(CheckLinks, self).__init__(parent, fspath=fspath)
-        else:
-            super(CheckLinks, self).__init__(fspath, parent)
+        super(CheckLinks, self).__init__(fspath, parent)
         self.check_anchors = check_anchors
         self.requests_session = requests_session
 

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -56,15 +56,15 @@ def pytest_configure(config):
         validate_extensions(config.option.links_ext)
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(fspath, parent):
     config = parent.config
     if config.option.check_links:
         requests_session = ensure_requests_session(config)
         if path.ext.lower() in config.option.links_ext:
             check_anchors = config.option.check_anchors
             if hasattr(CheckLinks, "from_parent"):
-                return CheckLinks.from_parent(parent, path=path, requests_session=requests_session, check_anchors=check_anchors)
-            return CheckLinks(path=path, parent=parent, requests_session=requests_session, check_anchors=check_anchors)
+                return CheckLinks.from_parent(parent, fspath=fspath, requests_session=requests_session, check_anchors=check_anchors)
+            return CheckLinks(fspath=fspath, parent=parent, requests_session=requests_session, check_anchors=check_anchors)
 
 def ensure_requests_session(config):
     """Build the singleton requests.Session (or subclass)
@@ -92,11 +92,11 @@ def ensure_requests_session(config):
 
 class CheckLinks(pytest.File):
     """Check the links in a file"""
-    def __init__(self, parent=None, path=None, requests_session=None, check_anchors=False):
+    def __init__(self, parent=None, fspath=None, requests_session=None, check_anchors=False):
         if hasattr(pytest.File, "from_parent"):
-            super(CheckLinks, self).__init__(parent, path=path)
+            super(CheckLinks, self).__init__(parent, fspath=fspath)
         else:
-            super(CheckLinks, self).__init__(path, parent)
+            super(CheckLinks, self).__init__(fspath, parent)
         self.check_anchors = check_anchors
         self.requests_session = requests_session
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ docutils
 html5lib
 nbconvert
 nbformat
-pytest >= 2.8
+pytest >= 4.6
 requests


### PR DESCRIPTION
cf https://github.com/jupyterlab/jupyterlab/pull/8737#issuecomment-665846668

From the traceback: https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent

```
==================================== ERRORS ====================================
________________________ ERROR collecting test session _________________________
/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/pluggy/manager.py:84: in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/pytest_check_links/plugin.py:64: in pytest_collect_file
    return CheckLinks(path, parent, requests_session, config.option.check_anchors)
/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/_pytest/nodes.py:95: in __call__
    warnings.warn(NODE_USE_FROM_PARENT.format(name=self.__name__), stacklevel=2)
E   pytest.PytestDeprecationWarning: Direct construction of CheckLinks has been deprecated, please use CheckLinks.from_parent.
E   See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.
=============================== warnings summary ===============================
/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages/_pytest/config/__init__.py:1148
```