### PR TITLE
Test with python 3.9 in CI, deal with some windows issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run python tests
         # disable automatic inclusion for coverage
         run: |
-          pytest -p no:check-links --cov pytest_check_links --cov-report term-missing
+          pytest -vv -p no:check-links --cov pytest_check_links --cov-report term-missing
       - name: Upload coverage
         run: |
           codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           architecture: 'x64'
       - name: Install python dependencies
         run: |
-          pip install setuptools pip --upgrade --user
+          pip install --upgrade --user setuptools pip wheel
           pip install --upgrade .[cache] pytest-cov codecov
       - name: Show python environment
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Setup python ${{ matrix.PYTHON_VERSION }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.PYTHON_VERSION }}
+          architecture: 'x64'
+      - name: Install python dependencies
+        run: |
+          pip install --upgrade --user setuptools pip wheel
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -33,15 +41,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.PYTHON_VERSION }}-
             ${{ runner.os }}-pip-
-      - name: Setup python ${{ matrix.PYTHON_VERSION }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.PYTHON_VERSION }}
-          architecture: 'x64'
-      - name: Install python dependencies
+      - name: Install package and dependencies
         run: |
-          pip install --upgrade --user setuptools pip wheel
-          pip install --upgrade .[cache] pytest-cov codecov
+          pip install --upgrade -vv .[cache] pytest-cov codecov
       - name: Show python environment
         run: |
           python --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,11 @@ jobs:
   linux:
     name: ${{ matrix.PLATFORM }} py${{ matrix.PYTHON_VERSION }}
     runs-on: ${{ matrix.PLATFORM }}
-    env:
-      CI: True
-      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.6', '3.8']
         PLATFORM: ['ubuntu-latest', 'macos-latest',  'windows-latest']
+        PYTHON_VERSION: ['3.6', '3.9']
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -28,7 +25,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-py-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('requirements.txt', 'setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-py-${{ matrix.PYTHON_VERSION }}-pip-
       - name: Setup python ${{ matrix.PYTHON_VERSION }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,13 +21,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
       - name: Cache pip
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ matrix.PYTHON_VERSION }}-pip-${{ hashFiles('requirements.txt', 'setup.cfg') }}
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ matrix.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'setup.cfg') }}
           restore-keys: |
-            ${{ runner.os }}-py-${{ matrix.PYTHON_VERSION }}-pip-
+            ${{ runner.os }}-pip-${{ matrix.PYTHON_VERSION }}-
+            ${{ runner.os }}-pip-
       - name: Setup python ${{ matrix.PYTHON_VERSION }}
         uses: actions/setup-python@v1
         with:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 pytest plugin that checks URLs for HTML-containing files.
 
 [![codecov](https://codecov.io/gh/jupyterlab/pytest-check-links/branch/master/graph/badge.svg)](https://codecov.io/gh/jupyterlab/pytest-check-links)
-[![Build Status](https://travis-ci.com/jupyterlab/pytest-check-links.svg?branch=master)](https://travis-ci.com/jupyterlab/pytest-check-links)
+[![Tests](https://github.com/jupyterlab/pytest-check-links/workflows/Tests/badge.svg)](https://github.com/jupyterlab/pytest-check-links/actions?query=workflow%3ATests+branch%3Amaster)
 [![PyPI version](https://badge.fury.io/py/pytest-check-links.svg)](https://badge.fury.io/py/pytest-check-links)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytest-check-links)
+
 
 ## Supported files
 

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -24,4 +24,4 @@ Some text to show that the reference links can follow later.
 
 [arbitrary case-insensitive reference text]: https://www.mozilla.org
 [1]: http://slashdot.org
-[link text itself]: http://www.reddit.com
+[link text itself]: https://www.w3.org

--- a/examples/rst.rst
+++ b/examples/rst.rst
@@ -15,7 +15,7 @@ reStructuredText file
 definitions <http://slashdot.org>`__
 
 Or leave it empty and use the `link text
-itself <http://www.reddit.com>`__.
+itself <https://www.w3.org>`__.
 
 URLs will automatically get turned into
 links. http://www.example.com or http://www.example.com/404.

--- a/examples/setup.cfg
+++ b/examples/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 filterwarnings =
     ignore::pytest.PytestAssertRewriteWarning
-    ignore:::win32[.*]
+    ignore:importlib:DeprecationWarning

--- a/examples/setup.cfg
+++ b/examples/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 filterwarnings =
     ignore::pytest.PytestAssertRewriteWarning
-    ignore:DeprecationWarning:pywintypes
+    ignore:::pywintypes[.*]

--- a/examples/setup.cfg
+++ b/examples/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+filterwarnings =
+    ignore::pytest.PytestAssertRewriteWarning

--- a/examples/setup.cfg
+++ b/examples/setup.cfg
@@ -1,3 +1,4 @@
 [tool:pytest]
 filterwarnings =
     ignore::pytest.PytestAssertRewriteWarning
+    ignore:DeprecationWarning:pywintypes

--- a/examples/setup.cfg
+++ b/examples/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 filterwarnings =
     ignore::pytest.PytestAssertRewriteWarning
-    ignore:importlib:DeprecationWarning
+    ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning

--- a/examples/setup.cfg
+++ b/examples/setup.cfg
@@ -1,4 +1,4 @@
 [tool:pytest]
 filterwarnings =
     ignore::pytest.PytestAssertRewriteWarning
-    ignore:::pywintypes[.*]
+    ignore:::win32[.*]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-pytester_example_dir = examples

--- a/pytest_check_links/__main__.py
+++ b/pytest_check_links/__main__.py
@@ -6,6 +6,8 @@ to collect further tests. If that is the case, you can disable
 these plugins with the py.test command line option
 "-p no:<plugin-name-here>".
 """
+# pragma: no cover
+
 import sys
 
 

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -167,7 +167,7 @@ def links_in_html(base_name, parent, html):
     """
     parsed = html5lib.parse(html, namespaceHTMLElements=False)
 
-    for element in parsed.getiterator():
+    for element in parsed.iter():
         url = None
         tag = element.tag
         if tag == 'a':

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,10 @@ ignore=E128
 
 [flake8]
 ignore=E128
+
+[tool:pytest]
+pytester_example_dir = examples
+
+filterwarnings =
+    ignore::FutureWarning:
+    ignore::DeprecationWarning:requests_cache

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,17 +7,28 @@ description-file = README.md
 long-description-content-type = text/markdown
 home-page = https://github.com/jupyterlab/pytest-check-links
 license = BSD-3-Clause
-python-requires = >=3.5
+python-requires = >=3.6
 classifier =
+    Framework :: Jupyter
+    Framework :: Pytest
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Documentation
+    Topic :: Documentation :: Sphinx
+    Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing
 keywords =
-    setup
-    distutils
+    testing
+    documentation
+    links
+    html
 
 [files]
 packages =

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-here = os.path.dirname(os.path.abspath(__file__))
-examples = os.path.join(os.path.dirname(here), 'examples')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,1 +1,20 @@
+import sys
+import pytest
+
 pytest_plugins = ["pytester"]
+
+skip_pywin32 = pytest.mark.skipif(sys.platform == "win32", reason="pywin32 double import")
+
+
+@pytest.fixture
+def anchor_args():
+    return ["-v", "--check-links", "--check-anchors"]
+
+@pytest.fixture
+def base_args():
+    return ["-v", "--check-links", "--check-links-cache"]
+
+
+@pytest.fixture
+def memory_args(base_args):
+    return base_args + ["--check-links-cache-backend", "memory"]

--- a/test/test_anchors.py
+++ b/test/test_anchors.py
@@ -1,11 +1,4 @@
-from . import examples
-
 import pytest
-
-
-@pytest.fixture
-def anchor_args():
-    return ["-v", "--check-links", "--check-anchors"]
 
 
 def test_anchors_local_self(testdir, anchor_args):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -8,18 +8,6 @@ import pytest
 
 import requests_cache
 
-from . import examples
-
-
-@pytest.fixture
-def base_args():
-    return ["-v", "--check-links", "--check-links-cache"]
-
-
-@pytest.fixture
-def memory_args(base_args):
-    return base_args + ["--check-links-cache-backend", "memory"]
-
 
 def assert_sqlite(testdir, name=None, tmpdir=None, exists=True):
     name = name or ".pytest-check-links-cache.sqlite"
@@ -59,7 +47,10 @@ def test_cache_expiry(testdir, base_args, cache_name, tmpdir):
     t3 = time.time()
     result.assert_outcomes(**expected)
 
-    assert t1 - t0 > t3 - t2, "cache did not make second run faster"
+    d0 = t1 - t0
+    d1 = t3 - t2
+
+    assert d0 > d1, "cache did not make second run faster"
 
     time.sleep(2)
 
@@ -68,7 +59,10 @@ def test_cache_expiry(testdir, base_args, cache_name, tmpdir):
     t5 = time.time()
     result.assert_outcomes(**expected)
 
-    assert t5 - t4 > t3 - t2, "cache did not expire"
+    d2 = t5 - t4
+    d3 = t3 - t2
+
+    assert d2 > d3, "cache did not expire"
 
 
 def test_cache_memory(testdir, memory_args):

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -1,4 +1,4 @@
-from . import examples
+from .conftest import skip_pywin32
 
 
 def test_ipynb(testdir):
@@ -11,6 +11,7 @@ def test_markdown(testdir):
     result = testdir.runpytest("-v", "--check-links")
     result.assert_outcomes(passed=8, failed=4)
 
+@skip_pywin32
 def test_rst(testdir):
     testdir.copy_example('rst.rst')
     result = testdir.runpytest("-v", "--check-links")
@@ -20,5 +21,5 @@ def test_link_ext(testdir):
     testdir.copy_example('linkcheck.ipynb')
     testdir.copy_example('rst.rst')
     testdir.copy_example('markdown.md')
-    result = testdir.runpytest("-v", "--check-links", "--links-ext=.md,rst")
-    result.assert_outcomes(passed=15, failed=6)
+    result = testdir.runpytest("-v", "--check-links", "--links-ext=md,ipynb")
+    result.assert_outcomes(passed=11, failed=7)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -19,6 +19,6 @@ def test_cli_pass(testdir, example, rc, expected, unexpected):
     summary = stdout.decode('utf-8').strip().splitlines()[-1]
     assert rc == proc.returncode
     for ex in expected:
-        assert ex in summary
+        assert ex in summary, stdout.decode('utf-8')
     for unex in unexpected:
-        assert unex not in summary
+        assert unex not in summary, stdout.decode('utf-8')

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,8 +8,8 @@ def test_cli_meta():
 
 
 @pytest.mark.parametrize("example,rc,expected,unexpected", [
-    ["httpbin.md", 0, ["6 passed"], ["failed", "warning"]],
-    ["rst.rst", 1, ["2 failed", "7 passed"], ["warning"]]
+    ["httpbin.md", 0, [" 6 passed"], ["failed", "warning"]],
+    ["rst.rst", 1, [" 2 failed", " 7 passed"], ["warning"]]
 ])
 def test_cli_pass(testdir, example, rc, expected, unexpected):
     testdir.copy_example(example)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,8 +8,8 @@ def test_cli_meta():
 
 
 @pytest.mark.parametrize("example,rc,expected,unexpected", [
-    ["httpbin.md", 0, [" 6 passed"], ["failed", "warning"]],
-    ["rst.rst", 1, [" 2 failed", " 7 passed"], ["warning"]]
+    ["httpbin.md", 0, [" 6 passed"], [" failed", " warning"]],
+    ["rst.rst", 1, [" 2 failed", " 7 passed"], [" warning"]]
 ])
 def test_cli_pass(testdir, example, rc, expected, unexpected):
     testdir.copy_example(example)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,24 @@
+import subprocess
+import pytest
+
+
+def test_cli_meta():
+    assert subprocess.call(["pytest-check-links", "--version"]) == 0
+    assert subprocess.call(["pytest-check-links", "--help"]) == 0
+
+
+@pytest.mark.parametrize("example,rc,expected,unexpected", [
+    ["httpbin.md", 0, ["6 passed"], ["failed", "warning"]],
+    ["rst.rst", 1, ["2 failed", "7 passed"], ["warning"]]
+])
+def test_cli_pass(testdir, example, rc, expected, unexpected):
+    testdir.copy_example(example)
+    testdir.copy_example("setup.cfg")
+    proc = subprocess.Popen(["pytest-check-links"], stdout=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    summary = stdout.decode('utf-8').strip().splitlines()[-1]
+    assert rc == proc.returncode
+    for ex in expected:
+        assert ex in summary
+    for unex in unexpected:
+        assert unex not in summary


### PR DESCRIPTION
- includes #26 (thanks @AnnaDinaburgVulikh!) 
  - fixes #13
- meta
  - updates required python to 3.6
  - update badges, keywords, and classifiers
- ci
  - adds py39 to ci matrix
    - the change from #26 is a real error there! 
  - adds some more test output
  - fixes cache locations on osx/win
  - adds restore keys for cache for partial hits
- tests
  - skips `rst`-based stuff on windows
    - double import of `pywin32`, nothing we can do!
  - adds cli tests
    - the rst _does_ get test on windows, so am okay with above skips
      - still not showing coverage for `__main__`, whatever
