### PR TITLE
Add Ability to Ignore Link Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Also check whether links with `#anchors` HTML files (either local, or with
 served with `html` in the `Content-Type`) actually exist, and point to _exactly one_
 named anchor.
 
-#### --link-check-ignore
+#### --check-links-ignore
 
 A regular expression that matches URIs that should not be checked.
 Can be specified multiple times for multiple ignore patterns.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Also check whether links with `#anchors` HTML files (either local, or with
 served with `html` in the `Content-Type`) actually exist, and point to _exactly one_
 named anchor.
 
+#### --link-check-ignore
+
+A regular expression that matches URIs that should not be checked.
+Can be specified multiple times for multiple ignore patterns.
+This can be used for files that have a lot of links to GitHub pages,
+such as a Changelog.  GitHub has rate limiting, which would normally cause these files to take up to an hour to complete for larger repositories.  For example:
+
+    pytest --check-links --link-check-ignore "https://github.com/.*/pull/.*" CHANGELOG.md
+
 ### Cache
 
 Caching requires the installation of `requests-cache`.

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -37,7 +37,7 @@ def pytest_addoption(parser):
              "as a comma-separated list of values. Supported "
              "extensions are: %s." %
                 extensions_str(supported_extensions))
-    group.addoption('--link-check-ignore', action='append',
+    group.addoption('--check-links-ignore', action='append',
         help="A list of regular expressions that match URIs that should not be checked.")
     group.addoption('--check-links-cache', action='store_true',
         help="Cache requests when checking links")
@@ -61,7 +61,7 @@ def pytest_configure(config):
 
 def pytest_collect_file(path, parent):
     config = parent.config
-    ignore_links = config.option.link_check_ignore
+    ignore_links = config.option.check_links_ignore
     if config.option.check_links:
         requests_session = ensure_requests_session(config)
         if path.ext.lower() in config.option.links_ext:

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -10,7 +10,7 @@ def test_markdown(testdir):
     testdir.copy_example('markdown.md')
     result = testdir.runpytest("-v", "--check-links")
     result.assert_outcomes(passed=8, failed=4)
-    result = testdir.runpytest("-v", "--check-links", "--link-check-ignore", "http.*example.com/.*")
+    result = testdir.runpytest("-v", "--check-links", "--check-links-ignore", "http.*example.com/.*")
     result.assert_outcomes(passed=8, failed=1)
 
 @skip_pywin32

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -10,6 +10,8 @@ def test_markdown(testdir):
     testdir.copy_example('markdown.md')
     result = testdir.runpytest("-v", "--check-links")
     result.assert_outcomes(passed=8, failed=4)
+    result = testdir.runpytest("-v", "--check-links", "--link-check-ignore", "http.*example.com/.*")
+    result.assert_outcomes(passed=8, failed=1)
 
 @skip_pywin32
 def test_rst(testdir):


### PR DESCRIPTION
Adds the following:

#### --link-check-ignore

A regular expression that matches URIs that should not be checked.
Can be specified multiple times for multiple ignore patterns.
This can be used for files that have a lot of links to GitHub pages,
such as a Changelog.  GitHub has rate limiting, which would normally cause these files to take up to an hour to complete for larger repositories.  For example:

    pytest --check-links --link-check-ignore "https://github.com/.*/pull/.*" CHANGELOG.md