### PR TITLE
Handle attachments in notebook cells

### DIFF
--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -124,14 +124,16 @@ class CheckLinks(pytest.File):
     def _items_from_notebook(self):
         """Yield LinkItems from a notebook"""
         import nbformat
-        from nbconvert.filters import markdown2html
+        from nbconvert.filters.markdown_mistune import IPythonRenderer, MarkdownWithMath
 
         nb = nbformat.read(str(self.fspath), as_version=4)
         for cell_num, cell in enumerate(nb.cells):
             if cell.cell_type != 'markdown':
                 continue
 
-            html = markdown2html(cell.source)
+            attachments = cell.get('attachments', {})
+            renderer = IPythonRenderer(escape=False, attachments=attachments)
+            html = MarkdownWithMath(renderer=renderer).render(cell.source)
             basename = 'Cell %i' % cell_num
             for item in links_in_html(basename, self, html):
                 yield item

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ console_scripts =
 
 [options.extras_require]
 cache =
-    requests-cache
+    requests-cache~=0.5.2
 
 [pep8]
 ignore=E128

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,7 +8,7 @@ def test_cli_meta():
 
 
 @pytest.mark.parametrize("example,rc,expected,unexpected", [
-    ["httpbin.md", 0, [" 6 passed"], [" failed", " warning"]],
+    ["httpbin.md", 0, [" 6 passed"], [" failed"]],
     ["rst.rst", 1, [" 2 failed", " 7 passed"], [" warning"]]
 ])
 def test_cli_pass(testdir, example, rc, expected, unexpected):


### PR DESCRIPTION
Fixes #35 

Manually create the `IPythonRenderer` and `MarkdownWithMath` objects to be able to pass the cell `attachments`.