### PR TITLE
Drop support for Python 3.6 and add support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PLATFORM: ['ubuntu-latest', 'macos-10.15',  'windows-latest']
-        PYTHON_VERSION: ['3.6', '3.9']
+        PLATFORM: ['ubuntu-latest', 'macos-latest',  'windows-latest']
+        PYTHON_VERSION: ['3.7', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup python ${{ matrix.PYTHON_VERSION }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
       - name: Cache pip
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'setup.cfg') }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ description-file = README.md
 long-description-content-type = text/markdown
 home-page = https://github.com/jupyterlab/pytest-check-links
 license = BSD-3-Clause
-python-requires = >=3.6
+python-requires = >=3.7
 classifier =
     Framework :: Jupyter
     Framework :: Pytest
@@ -16,10 +16,10 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Documentation
     Topic :: Documentation :: Sphinx
     Topic :: Software Development :: Quality Assurance


### PR DESCRIPTION
Accounts for the fact that 3.6 is EOL in December. This will require a minor version bump.