### PR TITLE
Fix prerelease tests

### DIFF
--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -16,9 +16,9 @@
 
 Or leave it empty and use the [link text itself].
 
-URLs and URLs in angle brackets will automatically get turned into links.
-http://www.example.com or <http://www.example.com> and sometimes
-example.com (but not on GitHub, for example). These will 404: http://example.com/404 <http://www.example.com/404>
+URLs in angle brackets will automatically get turned into links.
+<http://www.example.com> and sometimes
+example.com (but not on GitHub, for example). This will 404: <http://www.example.com/404>
 
 Some text to show that the reference links can follow later.
 

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -14,11 +14,11 @@ def test_ipynb(testdir):
 def test_markdown(testdir):
     testdir.copy_example("markdown.md")
     result = testdir.runpytest("-v", "--check-links")
-    result.assert_outcomes(passed=8, failed=4)
+    result.assert_outcomes(passed=7, failed=3)
     result = testdir.runpytest(
         "-v", "--check-links", "--check-links-ignore", "http.*example.com/.*"
     )
-    result.assert_outcomes(passed=8, failed=1)
+    result.assert_outcomes(passed=7, failed=1)
 
 
 def test_markdown_nested(testdir):
@@ -28,11 +28,11 @@ def test_markdown_nested(testdir):
     md.move(testdir.tmpdir / "nested" / "nested.md")
     testdir.copy_example("markdown.md")
     result = testdir.runpytest("-v", "--check-links")
-    result.assert_outcomes(passed=9, failed=4)
+    result.assert_outcomes(passed=8, failed=3)
     result = testdir.runpytest(
         "-v", "--check-links", "--check-links-ignore", "http.*example.com/.*"
     )
-    result.assert_outcomes(passed=9, failed=1)
+    result.assert_outcomes(passed=8, failed=1)
 
 
 @skip_pywin32


### PR DESCRIPTION
nbconvert 7 no longer handles raw URLs, but those are not strictly covered by Github Flavored Markdown