### PR TITLE
Use hatch backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling>=0.25"]
+build-backend = "hatchling.build"
 
 [project]
 name = "pytest_check_links"
+version = "0.7.1"
 description = "Check links in files"
 license = { file = "LICENSE" }
 classifiers = [
@@ -33,7 +34,6 @@ dependencies = [
   "pytest >= 7.0",
   "requests",
 ]
-dynamic = ["version"]
 
 [[project.authors]]
 name = "Jupyter Development Team"
@@ -56,9 +56,6 @@ pytest-check-links = "pytest_check_links.__main__:main"
 [project.entry-points."pytest11"]
 check-links = "pytest_check_links.plugin"
 
-[tool.flit.sdist]
-include = ["examples", "test/"]
-
 [tool.jupyter-releaser]
 skip = ["check-links"]
 
@@ -78,6 +75,9 @@ tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
 src = "pytest_check_links/_version.py"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
 
 [tool.pytest.ini_options]
 addopts = "-raXs --durations 10 --color=yes --doctest-modules"


### PR DESCRIPTION
Hatch is newly added pypa backend with more flexibility, and helps avoid https://github.com/pypa/pip/issues/11110, which is breaking builds.