### PR TITLE
Don't test truthiness of html5lib match

### DIFF
--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -425,7 +425,7 @@ class LinkItem(pytest.Item):
                 url, anchor = url.split("#")
 
             if not url and anchor:
-                if self.parent.check_anchors and self.parsed:
+                if self.parent.check_anchors and self.parsed is not None and len(self.parsed):
                     self.handle_anchor(self.parsed, anchor)
                 return None
 


### PR DESCRIPTION
This follows the advice offered by the `DeprecationWarning`:

```
.../pytest_check_links/plugin.py:428: DeprecationWarning: Testing an element's truth value will 
    raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
        if self.parent.check_anchors and self.parsed:
```

Observed with:
- `html5lib 1.1`
- `pytest-check-links 0.10.1`
- `pytest 8.1.2`
