### PR TITLE
Add link check controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ such as a Changelog. GitHub has rate limiting, which would normally cause these 
 pytest --check-links --check-links-ignore "https://github.com/.*/pull/.*" CHANGELOG.md
 ```
 
+#### --check-links-request-timeout
+
+> default: `None` (unset)
+
+Request timeout in seconds for external links.
+
+#### --check-links-transient-status-codes
+
+HTTP status codes to treat as transient failures, provided as comma-separated
+codes and ranges, such as `408,429,503..504`. Spaces are also accepted inside
+a quoted value, such as `"408 429 503..504"`.
+
+#### --check-links-transient-result
+
+> default: `fail`
+
+Result for transient failures. Allowed values are `skip` and `fail`.
+
 ### Cache
 
 Caching requires the installation of `requests-cache`.
@@ -91,18 +109,21 @@ for more information.
 
 Time to cache link responses (seconds).
 
+#### --check-links-cache-allowable-codes
+
+> default: `200..399`
+
+HTTP response codes to cache, provided as comma-separated codes and ranges,
+such as `200,301,304`. Spaces are also accepted inside a quoted value, such as
+`"200 301 304"`.
+
 #### --check-links-cache-backend-opt
 
 Backend-specific options for link cache, provided as `key:value`. These are passed
 directly to the `requests_cache.CachedSession` constructor, as they vary depending
 on the backend.
 
-Values will be parsed as JSON first, so to overload the default of caching all
-HTTP response codes (which requires a list of `int`s):
-
-```bash
---check-links-backend-opt allowable_codes:[200]
-```
+Values will be parsed as JSON first.
 
 ## Code Styling
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ on the backend.
 
 Values will be parsed as JSON first.
 
+For example:
+
+```bash
+--check-links-cache-backend-opt allowable_codes:[200]
+```
+
 ## Code Styling
 
 `pytest-check-links` has adopted automatic code formatting so you shouldn't

--- a/pytest_check_links/args.py
+++ b/pytest_check_links/args.py
@@ -3,7 +3,55 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from typing import Any
+
+
+def parse_status_codes(spec: str) -> list[int]:
+    """Parse HTTP status codes and ranges."""
+    codes: set[int] = set()
+    for token in re.split(r"[\s,]+", spec.strip()):
+        if not token:
+            continue
+
+        if ".." in token:
+            parts = token.split("..", 1)
+        elif "-" in token:
+            parts = token.split("-", 1)
+        else:
+            parts = [token]
+
+        try:
+            if len(parts) == 1:
+                start = end = int(parts[0])
+            else:
+                start, end = int(parts[0]), int(parts[1])
+        except ValueError as err:
+            msg = f"Invalid HTTP status code: {token}"
+            raise argparse.ArgumentTypeError(msg) from err
+
+        if start > end:
+            msg = f"Invalid HTTP status range: {token}"
+            raise argparse.ArgumentTypeError(msg)
+        if start < 100 or end > 599:
+            msg = f"Invalid HTTP status code: {token}"
+            raise argparse.ArgumentTypeError(msg)
+        codes.update(range(start, end + 1))
+
+    return sorted(codes)
+
+
+def parse_timeout(spec: str) -> float:
+    """Parse a positive request timeout."""
+    try:
+        timeout = float(spec)
+    except ValueError as err:
+        msg = f"Invalid request timeout: {spec}"
+        raise argparse.ArgumentTypeError(msg) from err
+    if timeout <= 0:
+        msg = "Request timeout must be greater than 0"
+        raise argparse.ArgumentTypeError(msg)
+    return timeout
 
 
 class StoreExtensionsAction(argparse.Action):
@@ -54,6 +102,8 @@ class StoreCacheAction(argparse.Action):
             kwargs["cache_name"] = values
         elif dest == "expire_after":
             kwargs["expire_after"] = float(values)
+        elif dest == "allowable_codes":
+            kwargs["allowable_codes"] = parse_status_codes(values)
         elif dest == "backend_opt":
             key, value = str(values).split(":", 1)
             try:

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -6,16 +6,17 @@ import re
 import time
 import warnings
 from pathlib import Path
-from typing import Any, Generator, cast
+from typing import Any, Generator, NoReturn, cast
 from xml.etree.ElementTree import Element
 
 import html5lib
 import pytest
 from docutils.core import publish_parts
 from requests import Request, Response, Session
+from requests.exceptions import Timeout
 from requests.utils import unquote  # type:ignore[attr-defined]
 
-from .args import StoreCacheAction, StoreExtensionsAction
+from .args import StoreCacheAction, StoreExtensionsAction, parse_status_codes, parse_timeout
 
 _ENC = "utf8"
 
@@ -26,7 +27,7 @@ default_cache = {
     "cache_name": ".pytest-check-links-cache",
     "backend": None,
     "expire_after": None,
-    "allowable_codes": list(range(200, 512)),
+    "allowable_codes": list(range(200, 400)),
 }
 
 
@@ -69,6 +70,22 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--check-links-cache-backend-opt",
         action=StoreCacheAction,
         help="Backend-specific options for link cache, specified as `opt:value`",
+    )
+    group.addoption(
+        "--check-links-request-timeout",
+        type=parse_timeout,
+        help="Request timeout in seconds when checking external links",
+    )
+    group.addoption(
+        "--check-links-transient-status-codes",
+        type=parse_status_codes,
+        help="HTTP response codes to treat as transient failures",
+    )
+    group.addoption(
+        "--check-links-transient-result",
+        choices=["skip", "fail"],
+        default="fail",
+        help="Result for transient failures",
     )
 
 
@@ -118,9 +135,16 @@ def ensure_requests_session(config: pytest.Config) -> Session:
             conf_kwargs = getattr(config.option, "check_links_cache_kwargs", {})
             kwargs = dict(default_cache)
             kwargs.update(conf_kwargs)
+            allowable_codes_opt = kwargs.get("allowable_codes")
+            if isinstance(allowable_codes_opt, str):
+                allowable_codes = parse_status_codes(allowable_codes_opt)
+            else:
+                allowable_codes = list(cast(Any, allowable_codes_opt or []))
+            kwargs["allowable_codes"] = allowable_codes
             requests_session = CachedSession(**kwargs)  # type:ignore[arg-type]
             if kwargs.get("expire_after"):
                 requests_session.cache.delete(expired=True)
+            purge_disallowed_cache(requests_session, allowable_codes)
         else:
             requests_session = Session()  # type:ignore[assignment]
 
@@ -129,6 +153,35 @@ def ensure_requests_session(config: pytest.Config) -> Session:
         setattr(config.option, session_attr, requests_session)
 
     return cast(Session, getattr(config.option, session_attr))
+
+
+def purge_disallowed_cache(session: Session, allowable_codes: list[int]) -> None:
+    """Remove cached responses outside the active cache status allowlist."""
+    cache = getattr(session, "cache", None)
+    if cache is None or not hasattr(cache, "filter") or not hasattr(cache, "delete"):
+        return
+
+    allowed = set(allowable_codes)
+    keys = []
+    for response in cache.filter():
+        if getattr(response, "status_code", None) in allowed:
+            continue
+        key = getattr(response, "cache_key", None)
+        request = getattr(response, "request", None)
+        if key is None and request is not None and hasattr(cache, "create_key"):
+            key = cache.create_key(request)
+        if key is not None:
+            keys.append(key)
+
+    if keys:
+        cache.delete(*keys)
+
+
+def session_caches_status(session: Session, status_code: int) -> bool:
+    """Whether a cached session is configured to cache a status code."""
+    settings = getattr(session, "settings", None)
+    allowable_codes = getattr(settings, "allowable_codes", None)
+    return allowable_codes is not None and status_code in allowable_codes
 
 
 class CheckLinks(pytest.File):
@@ -355,6 +408,13 @@ class LinkItem(pytest.Item):
                 self.target, "Ambiguous anchor: %d (found %s)" % (len(anchors), anchor)
             )
 
+    def handle_transient_failure(self, url: str, error: str) -> NoReturn:
+        """Report a transient link failure."""
+        message = f"transient link check failure: {error}"
+        if self.config.option.check_links_transient_result == "skip":
+            pytest.skip(f"{message} for {url}")
+        raise BrokenLinkError(url, message)
+
     def fetch_with_retries(self, url: str, retries: int = 3) -> Response:
         """Fetch a URL, optionally retrying after a delay (by header)"""
 
@@ -364,8 +424,15 @@ class LinkItem(pytest.Item):
             msg = "No session!"
             raise RuntimeError(msg)
 
+        timeout = self.config.option.check_links_request_timeout
+        kwargs = {"timeout": timeout} if timeout is not None else {}
+
         try:
-            response = session.get(url_no_anchor)
+            response = session.get(url_no_anchor, **kwargs)
+        except Timeout as err:
+            if timeout is not None:
+                self.handle_transient_failure(url, f"timeout: {err}")
+            raise BrokenLinkError(url, f"{err}") from err
         except Exception as err:
             if hasattr(err, "headers") and retries and self.sleep(err.headers):
                 self.uncache_url(url_no_anchor)
@@ -378,7 +445,14 @@ class LinkItem(pytest.Item):
                 self.uncache_url(url_no_anchor)
                 return self.fetch_with_retries(url, retries=retries - 1)
 
-            raise BrokenLinkError(url, "%d: %s" % (response.status_code, response.reason))
+            if hasattr(session, "cache") and not session_caches_status(session, response.status_code):
+                self.uncache_url(url_no_anchor)
+
+            error = f"{response.status_code}: {response.reason}"
+            transient_codes = self.config.option.check_links_transient_status_codes or []
+            if response.status_code in transient_codes:
+                self.handle_transient_failure(url, error)
+            raise BrokenLinkError(url, error)
 
         return response
 

--- a/pytest_check_links/plugin.py
+++ b/pytest_check_links/plugin.py
@@ -445,7 +445,9 @@ class LinkItem(pytest.Item):
                 self.uncache_url(url_no_anchor)
                 return self.fetch_with_retries(url, retries=retries - 1)
 
-            if hasattr(session, "cache") and not session_caches_status(session, response.status_code):
+            if hasattr(session, "cache") and not session_caches_status(
+                session, response.status_code
+            ):
                 self.uncache_url(url_no_anchor)
 
             error = f"{response.status_code}: {response.reason}"

--- a/test/test_check_links.py
+++ b/test/test_check_links.py
@@ -1,6 +1,104 @@
 import shutil
+from types import SimpleNamespace
+
+import pytest
+from requests import Response
+from requests.exceptions import Timeout
+
+from pytest_check_links.plugin import BrokenLinkError, LinkItem
 
 from .conftest import skip_pywin32
+
+
+class FakeSession:
+    def __init__(self, response=None, error=None):
+        self.headers = {}
+        self.calls = []
+        self.error = error
+        self.response = response
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        if self.error:
+            raise self.error
+        return self.response
+
+
+def make_response(status_code, reason):
+    response = Response()
+    response.status_code = status_code
+    response.reason = reason
+    response.headers = {}
+    return response
+
+
+def make_link_item(
+    session,
+    request_timeout=None,
+    transient_status_codes=None,
+    transient_result="fail",
+):
+    item = SimpleNamespace(
+        parent=SimpleNamespace(requests_session=session),
+        config=SimpleNamespace(
+            option=SimpleNamespace(
+                check_links_request_timeout=request_timeout,
+                check_links_transient_status_codes=transient_status_codes,
+                check_links_transient_result=transient_result,
+            )
+        ),
+        uncached=[],
+        sleep=lambda headers: False,
+    )
+
+    def uncache_url(url):
+        item.uncached.append(url)
+        return True
+
+    def handle_transient_failure(url, error):
+        return LinkItem.handle_transient_failure(item, url, error)
+
+    item.uncache_url = uncache_url
+    item.handle_transient_failure = handle_transient_failure
+    return item
+
+
+def test_fetch_with_retries_passes_configured_timeout():
+    session = FakeSession(response=make_response(200, "OK"))
+    item = make_link_item(session, request_timeout=7)
+
+    response = LinkItem.fetch_with_retries(item, "https://example.test/path#anchor")
+
+    assert response.status_code == 200
+    assert session.calls == [("https://example.test/path", {"timeout": 7})]
+
+
+def test_fetch_with_retries_preserves_unconfigured_timeout_failure():
+    session = FakeSession(error=Timeout("read timed out"))
+    item = make_link_item(session)
+
+    with pytest.raises(BrokenLinkError, match="read timed out"):
+        LinkItem.fetch_with_retries(item, "https://example.test")
+
+
+def test_fetch_with_retries_can_skip_configured_timeout_failure():
+    session = FakeSession(error=Timeout("read timed out"))
+    item = make_link_item(session, request_timeout=7, transient_result="skip")
+
+    with pytest.raises(pytest.skip.Exception, match="transient link check failure"):
+        LinkItem.fetch_with_retries(item, "https://example.test")
+
+
+def test_fetch_with_retries_uncaches_and_skips_transient_status():
+    session = FakeSession(response=make_response(503, "Service Unavailable"))
+    session.cache = object()
+    session.settings = SimpleNamespace(allowable_codes=[200, 301])
+    item = make_link_item(session, transient_status_codes=[503], transient_result="skip")
+
+    with pytest.raises(pytest.skip.Exception, match="503: Service Unavailable"):
+        LinkItem.fetch_with_retries(item, "https://example.test")
+
+    assert item.uncached == ["https://example.test"]
 
 
 def test_ipynb(pytester):

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -1,0 +1,75 @@
+import argparse
+
+import pytest
+
+from pytest_check_links.args import StoreCacheAction, parse_status_codes, parse_timeout
+from pytest_check_links.plugin import default_cache, purge_disallowed_cache
+
+
+def test_parse_status_codes_accepts_lists_and_ranges():
+    assert parse_status_codes("200, 301 400-402 500..501") == [
+        200,
+        301,
+        400,
+        401,
+        402,
+        500,
+        501,
+    ]
+
+
+def test_parse_status_codes_rejects_invalid_codes():
+    with pytest.raises(argparse.ArgumentTypeError, match="Invalid HTTP status"):
+        parse_status_codes("99")
+
+
+def test_parse_timeout_rejects_non_positive_values():
+    with pytest.raises(argparse.ArgumentTypeError, match="greater than 0"):
+        parse_timeout("0")
+
+
+def test_cache_allowable_codes_are_parsed():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check-links-cache-allowable-codes", action=StoreCacheAction)
+
+    namespace = parser.parse_args(["--check-links-cache-allowable-codes", "200, 301 400-402"])
+
+    assert namespace.check_links_cache_kwargs["allowable_codes"] == [200, 301, 400, 401, 402]
+
+
+def test_default_cache_allows_only_success_and_redirect_responses():
+    assert default_cache["allowable_codes"] == list(range(200, 400))
+
+
+def test_purge_disallowed_cache_removes_cached_responses_outside_allowlist():
+    class CachedResponse:
+        def __init__(self, status_code, cache_key):
+            self.status_code = status_code
+            self.cache_key = cache_key
+
+    class Cache:
+        def __init__(self):
+            self.deleted = []
+
+        def filter(self):
+            return iter(
+                [
+                    CachedResponse(200, "ok"),
+                    CachedResponse(302, "redirect"),
+                    CachedResponse(404, "missing"),
+                    CachedResponse(503, "unavailable"),
+                ]
+            )
+
+        def delete(self, *keys):
+            self.deleted.extend(keys)
+
+    class Session:
+        def __init__(self):
+            self.cache = Cache()
+
+    session = Session()
+
+    purge_disallowed_cache(session, [200, 302])
+
+    assert session.cache.deleted == ["missing", "unavailable"]


### PR DESCRIPTION
closes #145 

Adds native timeout, transient failure, and cache status controls for link checks.

- Add request timeout and transient result options
- Parse status code lists/ranges deterministically
- Limit default cached responses to 200..399
- Purge stale cached responses outside the active allowlist
- Document quoted space-separated status lists